### PR TITLE
Update io.github.tobagin.karere.yml

### DIFF
--- a/io.github.tobagin.karere.yml
+++ b/io.github.tobagin.karere.yml
@@ -45,5 +45,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/tobagin/karere.git
-        tag: v0.4.3
-        commit: 42014fc5e38f277cff25bdc1c729adfc884cdae6
+        tag: v0.4.4
+        commit: 2afd3bb8b5d86ab5a5cf455c4dd6b34e01e5c912


### PR DESCRIPTION
  1. Startup fix: "first-time-only" mode now works correctly on app startup by always tracking background notifications shown,
  regardless of current mode
  2. Mode switching fix: When switching from "always" to "first-time-only", notifications won't show again if already shown in the
  current session