### PR TITLE
Update io.github.tobagin.karere.yml

### DIFF
--- a/io.github.tobagin.karere.yml
+++ b/io.github.tobagin.karere.yml
@@ -45,5 +45,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/tobagin/karere.git
-        tag: v0.4.6
-        commit: 6ea48bf8e9d599de2e5b024e1bf2c7317001f562
+        tag: v0.5.0
+        commit: e424a03d32a84c852e3751ca390ea3bafde90a11

--- a/io.github.tobagin.karere.yml
+++ b/io.github.tobagin.karere.yml
@@ -46,4 +46,4 @@ modules:
       - type: git
         url: https://github.com/tobagin/karere.git
         tag: v0.5.0
-        commit: e424a03d32a84c852e3751ca390ea3bafde90a11
+        commit: 27c4bf57c17d1f4be38c9b6eb2351a5ca07b8b43


### PR DESCRIPTION
  Release v0.5.0 is now ready with:
  - Native WebKit notifications replacing JavaScript injection
  - 398 lines of code removed for better performance
  - Fixed dev/production app ID registration
  - Enhanced screenshot paste functionality
  - Proper semantic versioning reflecting the architectural significance