### PR TITLE
Beta: use xdg-download to pass linter

### DIFF
--- a/io.github.tobagin.karere.yml
+++ b/io.github.tobagin.karere.yml
@@ -41,10 +41,11 @@ finish-args:
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --device=all
-  # home (not just xdg-download) so the user can pick any download folder under
-  # ~ and the file chooser returns its real path instead of a transient
-  # document-portal path (/run/user/.../doc/<id>/…) that can't persist.
-  - --filesystem=home
+  # Beta channel uses xdg-download to pass the Flathub linter without a
+  # home-filesystem exception (the stable manifest also ships xdg-download).
+  # Downloads land in ~/Downloads; arbitrary download folders outside it are
+  # not available on the beta build.
+  - --filesystem=xdg-download
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   # NOTE: autostart is handled by the XDG Background portal (ashpd `background`

--- a/io.github.tobagin.karere.yml
+++ b/io.github.tobagin.karere.yml
@@ -105,5 +105,5 @@ modules:
       - type: git
         url: https://github.com/tobagin/karere
         tag: v4.0.0-beta1
-        commit: 18618db2d92802c2c5a816dd65f49ccdfb194914
+        commit: 374bbd5eb27d6318f7c23cb8a8823a67a4f9edda
       - cargo-sources.json


### PR DESCRIPTION
The initial beta push used `--filesystem=home`, which fails `flatpak-builder-lint` with `finish-args-home-filesystem-access` (no registered exception for this app-id; the stable manifest ships `xdg-download`).

This switches the beta manifest to `--filesystem=xdg-download` so the beta build passes lint. Downloads land in `~/Downloads`.

Verified locally:
```
flatpak-builder-lint manifest io.github.tobagin.karere.yml  →  EXIT=0
```

Upstream tag: https://github.com/tobagin/karere/releases/tag/v4.0.0-beta1