### PR TITLE
Update Karere to v4.0.0-beta3 (beta channel)

### DIFF
--- a/io.github.tobagin.karere.yml
+++ b/io.github.tobagin.karere.yml
@@ -43,8 +43,6 @@ finish-args:
   - --filesystem=xdg-download
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  # Relaunch on language change (single-instance app restarts via host).
-  - --talk-name=org.freedesktop.Flatpak
   # Autostart goes through the XDG Background portal (ashpd) — no autostart
   # filesystem or portal.Desktop talk-name needed (portal busnames auto-granted).
   - --env=LD_LIBRARY_PATH=/app/lib/cef

--- a/io.github.tobagin.karere.yml
+++ b/io.github.tobagin.karere.yml
@@ -43,6 +43,8 @@ finish-args:
   - --filesystem=xdg-download
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
+  # Relaunch on language change (single-instance app restarts via host).
+  - --talk-name=org.freedesktop.Flatpak
   # Autostart goes through the XDG Background portal (ashpd) — no autostart
   # filesystem or portal.Desktop talk-name needed (portal busnames auto-granted).
   - --env=LD_LIBRARY_PATH=/app/lib/cef
@@ -91,6 +93,12 @@ modules:
       # Flathub pulls the tagged GitHub source. Update tag + commit per beta.
       - type: git
         url: https://github.com/tobagin/karere
-        tag: v4.0.0-beta2
-        commit: ea6de8935fdf6225cfe875f2be593112c21a1981
+        tag: v4.0.0-beta3
+        commit: e284f8f2ea1c6f68f71f09bb236bcd942f8e03ac
       - cargo-sources.json
+    # Move our gettext catalogs out of share/locale so flatpak's automatic
+    # per-language .Locale extension (which only deploys the host's languages)
+    # doesn't strip the locales the in-app language picker offers.
+    post-install:
+      - mkdir -p ${FLATPAK_DEST}/share/karere
+      - mv ${FLATPAK_DEST}/share/locale ${FLATPAK_DEST}/share/karere/locale


### PR DESCRIPTION
Bumps the `karere` module to tag `v4.0.0-beta3` (commit `e284f8f`).

Highlights:
- In-app language picker (Preferences → Appearance → Language), expanding the UI from 9 to 72 locales (the Chromium spellcheck set + Galician/Armenian + the Chromium UI-only languages). The choice drives the gettext catalog, `CefSettings.locale`, and the WhatsApp Web locale (via the `wa_web_lang_pref` cookie + prefs-cache purge).
- Restart confirmation dialog on language change; relaunch via `flatpak-spawn` (single-instance app).
- OSR pump/redraw CPU hardening: single-pending message pump, bounded 60 Hz redraw timer, and visibility-gated compositing.

Manifest changes beyond the `tag`/`commit` pin (git-tag source form, beta channel):
- `--talk-name=org.freedesktop.Flatpak` for the single-instance relaunch.
- post-install moves catalogs out of `share/locale` so Flatpak's per-language `.Locale` extension doesn't strip the 72 locales the picker offers.

cargo-sources.json unchanged (no dependency changes).

Supersedes the auto-generated #148, which targeted `master` and used the in-tree `dir` source.