### PR TITLE
Update Karere to v4.0.0-beta3 (beta channel)

### DIFF
--- a/io.github.tobagin.karere.yml
+++ b/io.github.tobagin.karere.yml
@@ -91,6 +91,11 @@ modules:
       # Flathub pulls the tagged GitHub source. Update tag + commit per beta.
       - type: git
         url: https://github.com/tobagin/karere
-        tag: v4.0.0-beta2
-        commit: ea6de8935fdf6225cfe875f2be593112c21a1981
+        tag: v4.0.0-beta3
+        commit: d23843fb63652d4f03b7f5a81b67412fa39a7045
       - cargo-sources.json
+    # Move catalogs out of share/locale so flatpak's per-language .Locale
+    # extension doesn't strip the locales the in-app language picker offers.
+    post-install:
+      - mkdir -p ${FLATPAK_DEST}/share/karere
+      - mv ${FLATPAK_DEST}/share/locale ${FLATPAK_DEST}/share/karere/locale


### PR DESCRIPTION
Bumps the `karere` module to tag `v4.0.0-beta3` (commit `d23843f`).

Highlights:
- In-app language picker (Preferences → Appearance → Language), expanding the UI from 9 to 72 locales (the Chromium spellcheck set + Galician/Armenian + the Chromium UI-only languages). The choice drives the gettext catalog, `CefSettings.locale`, and the WhatsApp Web locale.
- Restart confirmation dialog on language change (relaunches by re-exec'ing the in-sandbox binary — no extra permission).
- OSR pump/redraw CPU hardening.

Manifest adds only the `post-install` locale move (keeps the 72 catalogs out of flatpak's per-language `.Locale` extension, which would otherwise deploy only the host's languages). cargo-sources.json unchanged.