### PR TITLE
Update Karere to 4.0.0-beta4

### DIFF
--- a/io.github.tobagin.karere.yml
+++ b/io.github.tobagin.karere.yml
@@ -66,12 +66,12 @@ modules:
       # archive.json keeps the .8 name so the crate's version check passes.
       - type: archive
         only-arches: [x86_64]
-        url: https://github.com/tobagin/karere/releases/download/cef-148.0.10-proprietary-codecs/cef_binary_148.0.10%2Bg7ee53f5%2Bchromium-148.0.7778.218_linux64_minimal.zip
-        sha256: c8a39eaf956131699012c1160f597bb81dda2e4a0995a8f8d6833dc0b0b25d20
+        url: https://github.com/tobagin/karere/releases/download/cef-148.0.10-proprietary-codecs-151fix/cef_binary_148.0.10%2Bg7ee53f5%2Bchromium-148.0.7778.218_linux64_minimal.zip
+        sha256: 8c388a503a1706e3eb09f843def41996082f806927ae7cbd0be7bc36981a164d
       - type: archive
         only-arches: [aarch64]
-        url: https://github.com/tobagin/karere/releases/download/cef-148.0.10-proprietary-codecs/cef_binary_148.0.10%2Bg7ee53f5%2Bchromium-148.0.7778.218_linuxarm64_minimal.zip
-        sha256: 5ad0d764ac9973a4a343879984afbbd1a742e225f28c7f6c57b61a21c6a1deda
+        url: https://github.com/tobagin/karere/releases/download/cef-148.0.10-proprietary-codecs-151fix/cef_binary_148.0.10%2Bg7ee53f5%2Bchromium-148.0.7778.218_linuxarm64_minimal.zip
+        sha256: a6500896f3ebaef1d4126e9818c874d6f0735b3d95acf092e36496af430c991c
       - type: inline
         only-arches: [x86_64]
         contents: |
@@ -91,11 +91,12 @@ modules:
       # Flathub pulls the tagged GitHub source. Update tag + commit per beta.
       - type: git
         url: https://github.com/tobagin/karere
-        tag: v4.0.0-beta3
-        commit: d23843fb63652d4f03b7f5a81b67412fa39a7045
+        tag: v4.0.0-beta4
+        commit: 924abbe3aa8b3824e260949fadf2563de7db5925
       - cargo-sources.json
-    # Move catalogs out of share/locale so flatpak's per-language .Locale
-    # extension doesn't strip the locales the in-app language picker offers.
+    # Move our gettext catalogs out of share/locale so flatpak's automatic
+    # per-language .Locale extension (which only deploys the host's languages)
+    # doesn't strip the locales the in-app language picker offers.
     post-install:
       - mkdir -p ${FLATPAK_DEST}/share/karere
       - mv ${FLATPAK_DEST}/share/locale ${FLATPAK_DEST}/share/karere/locale


### PR DESCRIPTION
Bumps the flathub-beta channel to **4.0.0-beta4**.

- **#151 idle-CPU fix**: repacked proprietary-codec CEF (`cef-148.0.10-proprietary-codecs-151fix`) whose libcef.so carries the WorkSource-detach patch — CEF's external message pump no longer spins one CPU core at 100% when the app is idle/backgrounded. Same chromium-148.0.7778.218 / cef g7ee53f5 source; only libcef.so differs.
- Service-worker notification regression fix.
- What's New dialog metainfo release-note parsing fix.

Karere source pinned to tag `v4.0.0-beta4` (commit `924abbe`).