### PR TITLE
Update Karere to 4.0.0-beta5

### DIFF
--- a/io.github.tobagin.karere.yml
+++ b/io.github.tobagin.karere.yml
@@ -91,8 +91,8 @@ modules:
       # Flathub pulls the tagged GitHub source. Update tag + commit per beta.
       - type: git
         url: https://github.com/tobagin/karere
-        tag: v4.0.0-beta4
-        commit: 924abbe3aa8b3824e260949fadf2563de7db5925
+        tag: v4.0.0-beta5
+        commit: 8705eb9558671a2c8fe215a8402e48cf793ff80b
       - cargo-sources.json
     # Move our gettext catalogs out of share/locale so flatpak's automatic
     # per-language .Locale extension (which only deploys the host's languages)


### PR DESCRIPTION
Bumps the flathub-beta channel to **4.0.0-beta5**.

- **Renderer memory**: collapse WhatsApp's per-frame site isolation so its cross-origin frames share one renderer process instead of forking extra ones — ~200 MB RSS and one process saved per account, measured on a single-account session. Per-account isolation is still enforced at the CEF RequestContext level.
- CEF unchanged (still the #151 idle-CPU-patched `cef-148.0.10-proprietary-codecs-151fix`).

Karere source pinned to tag `v4.0.0-beta5` (commit `8705eb9`).